### PR TITLE
EIP712 spec

### DIFF
--- a/src/contracts/EIP712MetaTransaction.sol
+++ b/src/contracts/EIP712MetaTransaction.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.5.13;
+pragma solidity 0.6.6;
 
 import "./lib/EIP712Base.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";

--- a/src/contracts/TestContract.sol
+++ b/src/contracts/TestContract.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.5.13;
+pragma solidity 0.6.6;
 
 import "./EIP712MetaTransaction.sol";
 

--- a/src/contracts/lib/EIP712Base.sol
+++ b/src/contracts/lib/EIP712Base.sol
@@ -1,26 +1,26 @@
 //SPDX-License-Identifier: MIT
-pragma solidity 0.5.13;
+pragma solidity ^0.6.0;
 
 contract EIP712Base {
 
     struct EIP712Domain {
         string name;
         string version;
-        uint256 salt;
         address verifyingContract;
+        bytes32 salt;
     }
 
-    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(bytes("EIP712Domain(string name,string version,uint256 salt,address verifyingContract)"));
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH = keccak256(bytes("EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"));
 
-    bytes32 internal domainSeperator;
+    bytes32 internal domainSeparator;
 
     constructor(string memory name, string memory version) public {
-        domainSeperator = keccak256(abi.encode(
+        domainSeparator = keccak256(abi.encode(
             EIP712_DOMAIN_TYPEHASH,
             keccak256(bytes(name)),
             keccak256(bytes(version)),
-            getChainID(),
-            address(this)
+            address(this),
+            bytes32(getChainID())
         ));
     }
 
@@ -30,8 +30,8 @@ contract EIP712Base {
         }
     }
 
-    function getDomainSeperator() private view returns(bytes32) {
-        return domainSeperator;
+    function getDomainSeparator() private view returns(bytes32) {
+        return domainSeparator;
     }
 
     /**
@@ -42,7 +42,7 @@ contract EIP712Base {
     * "\\x01" is the version byte to make it compatible to EIP-191
     */
     function toTypedMessageHash(bytes32 messageHash) internal view returns(bytes32) {
-        return keccak256(abi.encodePacked("\x19\x01", getDomainSeperator(), messageHash));
+        return keccak256(abi.encodePacked("\x19\x01", getDomainSeparator(), messageHash));
     }
 
 }

--- a/src/contracts/lib/EIP712Base.sol
+++ b/src/contracts/lib/EIP712Base.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity 0.6.6;
 
 contract EIP712Base {
 

--- a/src/package.json
+++ b/src/package.json
@@ -18,7 +18,7 @@
   "author": "Sachin Tomar",
   "license": "ISC",
   "dependencies": {
-    "@openzeppelin/contracts": "^2.3.0",
+    "@openzeppelin/contracts": "^3.4.0",
     "chai": "^4.2.0",
     "eth-sig-util": "^2.5.3",
     "ganache-cli": "^6.10.2",

--- a/src/truffle-config.js
+++ b/src/truffle-config.js
@@ -100,14 +100,13 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      version: "0.5.13",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "0.6.6",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       settings: {          // See the solidity docs for advice about optimization and evmVersion
-      //  optimizer: {
-      //    enabled: true,
-      //    runs: 200
-      //  },
-       evmVersion: "istanbul"
+        optimizer: {
+          enabled: true,
+          runs: 200
+        },
       }
     }
   },

--- a/src/truffle-config.js
+++ b/src/truffle-config.js
@@ -107,6 +107,7 @@ module.exports = {
           enabled: true,
           runs: 200
         },
+      evmVersion: 'berlin'
       }
     }
   },


### PR DESCRIPTION
The DOMAIN_HASH should be strictly followed in which the variables names and order is important. The order of variables cannot be changed and only can be removed from the DOMAIN_HASH. This is to comply with the standard.